### PR TITLE
Minor change on DeleteHandlerTest response assertion

### DIFF
--- a/aws-msk-serverlesscluster/src/test/java/software/amazon/msk/serverlesscluster/DeleteHandlerTest.java
+++ b/aws-msk-serverlesscluster/src/test/java/software/amazon/msk/serverlesscluster/DeleteHandlerTest.java
@@ -114,6 +114,7 @@ public class DeleteHandlerTest extends AbstractTestBase {
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isNull();
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
@@ -147,6 +148,7 @@ public class DeleteHandlerTest extends AbstractTestBase {
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isNull();
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Assert `response.getResourceModels()` to be `null` in success case of DeleteHandlerTest

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
