### PR TITLE
Add support for updatable tagging

### DIFF
--- a/aws-msk-serverlesscluster/aws-msk-serverlesscluster.json
+++ b/aws-msk-serverlesscluster/aws-msk-serverlesscluster.json
@@ -104,8 +104,7 @@
   "createOnlyProperties": [
     "/properties/ClusterName",
     "/properties/VpcConfigs",
-    "/properties/ClientAuthentication",
-    "/properties/Tags"
+    "/properties/ClientAuthentication"
   ],
   "primaryIdentifier": [
     "/properties/Arn"
@@ -116,7 +115,7 @@
   "tagging": {
     "taggable": true,
     "tagOnCreate": true,
-    "tagUpdatable": false,
+    "tagUpdatable": true,
     "cloudFormationSystemTags": true,
     "tagProperty": "/properties/Tags"
   },
@@ -138,6 +137,12 @@
     "read": {
       "permissions": [
         "kafka:DescribeClusterV2"
+      ]
+    },
+    "update": {
+      "permissions": [
+        "kafka:TagResource",
+        "kafka:UntagResource"
       ]
     },
     "delete": {

--- a/aws-msk-serverlesscluster/docs/README.md
+++ b/aws-msk-serverlesscluster/docs/README.md
@@ -70,7 +70,7 @@ _Required_: No
 
 _Type_: <a href="tags.md">Tags</a>
 
-_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 ## Return Values
 

--- a/aws-msk-serverlesscluster/resource-role.yaml
+++ b/aws-msk-serverlesscluster/resource-role.yaml
@@ -43,6 +43,7 @@ Resources:
                 - "kafka:DescribeClusterV2"
                 - "kafka:ListClustersV2"
                 - "kafka:TagResource"
+                - "kafka:UntagResource"
                 Resource: "*"
 Outputs:
   ExecutionRoleArn:

--- a/aws-msk-serverlesscluster/src/main/java/software/amazon/msk/serverlesscluster/CreateHandler.java
+++ b/aws-msk-serverlesscluster/src/main/java/software/amazon/msk/serverlesscluster/CreateHandler.java
@@ -32,7 +32,7 @@ public class CreateHandler extends BaseHandlerStd {
         logger.log( String.format("[Request: %s] Handling create operation, resource model: %s", clientRequestToken,
             model));
 
-        model.setTags(request.getDesiredResourceTags());
+        model.setTags(TagHelper.generateTagsForCreate(request));
 
         return ProgressEvent.progress(model, callbackContext)
             .then(progress ->

--- a/aws-msk-serverlesscluster/src/main/java/software/amazon/msk/serverlesscluster/TagHelper.java
+++ b/aws-msk-serverlesscluster/src/main/java/software/amazon/msk/serverlesscluster/TagHelper.java
@@ -1,0 +1,87 @@
+package software.amazon.msk.serverlesscluster;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+public class TagHelper {
+    /**
+     * generateTagsForCreate
+     *
+     * Generate tags to put into resource creation request.
+     */
+    static final Map<String, String> generateTagsForCreate(final ResourceHandlerRequest<ResourceModel> handlerRequest) {
+        final Map<String, String> tagMap = new HashMap<>();
+        if (handlerRequest.getDesiredResourceTags() != null) {
+            tagMap.putAll(handlerRequest.getDesiredResourceTags());
+        }
+        return Collections.unmodifiableMap(tagMap);
+    }
+
+    /**
+     * getPreviouslyAttachedTags
+     *
+     * If stack tags and resource tags are not merged together in Configuration class,
+     * we will get previous attached user defined tags from both handlerRequest.getPreviousResourceTags (stack tags)
+     * and handlerRequest.getPreviousResourceState (resource tags).
+     */
+    static Map<String, String> getPreviouslyAttachedTags(final ResourceHandlerRequest<ResourceModel> handlerRequest) {
+        // get previous stack level tags from handlerRequest
+        final Map<String, String> previousTags = handlerRequest.getPreviousResourceTags() != null ?
+            handlerRequest.getPreviousResourceTags() : new HashMap<>();
+        if (handlerRequest.getPreviousResourceState() != null && handlerRequest.getPreviousResourceState().getTags() != null) {
+            previousTags.putAll(handlerRequest.getPreviousResourceState().getTags());
+        }
+        return previousTags;
+    }
+
+    /**
+     * getNewDesiredTags
+     *
+     * If stack tags and resource tags are not merged together in Configuration class,
+     * we will get new user defined tags from both resource model and previous stack tags.
+     */
+    static Map<String, String> getNewDesiredTags(final ResourceHandlerRequest<ResourceModel> handlerRequest) {
+        // get new stack level tags from handlerRequest
+        final Map<String, String> desiredTags = handlerRequest.getDesiredResourceTags() != null ?
+            handlerRequest.getDesiredResourceTags() : new HashMap<>();
+        if (handlerRequest.getDesiredResourceState() != null && handlerRequest.getDesiredResourceState().getTags() != null) {
+            desiredTags.putAll(handlerRequest.getDesiredResourceState().getTags());
+        }
+        return desiredTags;
+    }
+
+    /**
+     * generateTagsToAdd
+     *
+     * Determines the tags the customer desired to define or redefine.
+     */
+    static Map<String, String> generateTagsToAdd(final Map<String, String> previousTags,
+                                                 final Map<String, String> desiredTags) {
+        return desiredTags.entrySet().stream()
+            .filter(e -> !previousTags.containsKey(e.getKey()) ||
+                !Objects.equals(previousTags.get(e.getKey()), e.getValue()))
+            .collect(Collectors.toMap(
+                Map.Entry::getKey,
+                Map.Entry::getValue));
+    }
+
+    /**
+     * getTagsToRemove
+     *
+     * Determines the tags the customer desired to remove from the function.
+     */
+    static Set<String> generateTagsToRemove(final Map<String, String> previousTags,
+                                            final Map<String, String> desiredTags) {
+        final Set<String> desiredTagNames = desiredTags.keySet();
+
+        return previousTags.keySet().stream()
+            .filter(tagName -> !desiredTagNames.contains(tagName))
+            .collect(Collectors.toSet());
+    }
+}

--- a/aws-msk-serverlesscluster/src/main/java/software/amazon/msk/serverlesscluster/Translator.java
+++ b/aws-msk-serverlesscluster/src/main/java/software/amazon/msk/serverlesscluster/Translator.java
@@ -2,7 +2,9 @@ package software.amazon.msk.serverlesscluster;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -20,6 +22,8 @@ import software.amazon.awssdk.services.kafka.model.ListClustersV2Response;
 import software.amazon.awssdk.services.kafka.model.ServerlessClientAuthentication;
 import software.amazon.awssdk.services.kafka.model.ServerlessRequest;
 import software.amazon.awssdk.services.kafka.model.ServerlessSasl;
+import software.amazon.awssdk.services.kafka.model.TagResourceRequest;
+import software.amazon.awssdk.services.kafka.model.UntagResourceRequest;
 import software.amazon.awssdk.services.kafka.model.VpcConfig;
 
 /**
@@ -131,6 +135,36 @@ public class Translator {
         return streamOfOrEmpty(clustersList)
             .map(cluster -> ResourceModel.builder().arn(cluster.clusterArn()).build())
             .collect(Collectors.toList());
+    }
+
+    /**
+     * Request to tag resources within aws account
+     *
+     * @param model resource model
+     * @param addedTags tags to be added
+     * @return tagResourceRequest the aws service request to tag resources within aws account
+     */
+    static TagResourceRequest translateToTagResourceRequest(final ResourceModel model,
+                                                            final Map<String, String> addedTags) {
+        return TagResourceRequest.builder()
+            .resourceArn(model.getArn())
+            .tags(addedTags)
+            .build();
+    }
+
+    /**
+     * Request to untag resources within aws account
+     *
+     * @param model resource model
+     * @param removedTags keys of the tags to be removed
+     * @return untagResourceRequest the aws service request to untag resources within aws account
+     */
+    static UntagResourceRequest translateToUntagResourceRequest(final ResourceModel model,
+                                                                final Set<String> removedTags) {
+        return UntagResourceRequest.builder()
+            .resourceArn(model.getArn())
+            .tagKeys(removedTags)
+            .build();
     }
 
     private static <T> Stream<T> streamOfOrEmpty(final Collection<T> collection) {

--- a/aws-msk-serverlesscluster/src/main/java/software/amazon/msk/serverlesscluster/UpdateHandler.java
+++ b/aws-msk-serverlesscluster/src/main/java/software/amazon/msk/serverlesscluster/UpdateHandler.java
@@ -1,0 +1,101 @@
+package software.amazon.msk.serverlesscluster;
+
+import java.util.Map;
+import java.util.Set;
+
+import software.amazon.awssdk.services.kafka.KafkaClient;
+import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+public class UpdateHandler extends BaseHandlerStd {
+    private Logger logger;
+
+    protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+        final AmazonWebServicesClientProxy proxy,
+        final ResourceHandlerRequest<ResourceModel> request,
+        final CallbackContext callbackContext,
+        final ProxyClient<KafkaClient> proxyClient,
+        final Logger logger) {
+
+        this.logger = logger;
+
+        final ResourceModel resourceModel = request.getDesiredResourceState();
+        final String clientRequestToken = request.getClientRequestToken();
+
+        if(request.getPreviousResourceState() == null) {
+            throw new CfnInvalidRequestException("PreviousResourceState is required.");
+        }
+
+        final Map<String, String> previousTags = TagHelper.getPreviouslyAttachedTags(request);
+        final Map<String, String> desiredTags = TagHelper.getNewDesiredTags(request);
+        final Map<String, String> addedTags = TagHelper.generateTagsToAdd(previousTags, desiredTags);
+        final Set<String> removedTags = TagHelper.generateTagsToRemove(previousTags, desiredTags);
+
+        return ProgressEvent.progress(resourceModel, callbackContext)
+            .then(progress -> untagResource(proxy, proxyClient, resourceModel, request, callbackContext, progress,
+                clientRequestToken, removedTags))
+            .then(progress -> tagResource(proxy, proxyClient, resourceModel, request, callbackContext, progress,
+                clientRequestToken, addedTags))
+            .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger));
+    }
+
+    /**
+     * tagResource during update
+     *
+     * Calls the kafka:TagResource API.
+     */
+    private ProgressEvent<ResourceModel, CallbackContext>
+    tagResource(final AmazonWebServicesClientProxy proxy, final ProxyClient<KafkaClient> serviceClient,
+                final ResourceModel resourceModel,
+                final ResourceHandlerRequest<ResourceModel> handlerRequest, final CallbackContext callbackContext,
+                final ProgressEvent<ResourceModel, CallbackContext> progressEvent, final String clientRequestToken,
+                final Map<String, String> addedTags) {
+        if (addedTags.isEmpty()) {
+            return ProgressEvent.progress(resourceModel, progressEvent.getCallbackContext());
+        }
+
+        logger.log(String.format("Going to add tags for MSK ServerlessCluster resource: " +
+            "%s with AccountId: %s", resourceModel.getClusterName(), handlerRequest.getAwsAccountId()));
+
+        return proxy.initiate("AWS-MSK-ServerlessCluster::TagResource", serviceClient, resourceModel, callbackContext)
+            .translateToServiceRequest(model ->
+                Translator.translateToTagResourceRequest(resourceModel, addedTags))
+            .makeServiceCall((tagResourceRequest, _proxyClient) -> _proxyClient.injectCredentialsAndInvokeV2(
+                tagResourceRequest, _proxyClient.client()::tagResource))
+            .handleError((tagResourceRequest, exception, _proxyClient, _resourceModel, _callbackContext) ->
+                handleError(exception, resourceModel,  callbackContext, logger, clientRequestToken))
+            .progress();
+    }
+
+    /**
+     * untagResource during update
+     *
+     * Calls the kafka:UntagResource API.
+     */
+    private ProgressEvent<ResourceModel, CallbackContext>
+    untagResource(final AmazonWebServicesClientProxy proxy, final ProxyClient<KafkaClient> serviceClient,
+                  final ResourceModel resourceModel,
+                  final ResourceHandlerRequest<ResourceModel> handlerRequest, final CallbackContext callbackContext,
+                  final ProgressEvent<ResourceModel, CallbackContext> progressEvent, final String clientRequestToken,
+                  final Set<String> removedTags) {
+        if (removedTags.isEmpty()) {
+            return ProgressEvent.progress(resourceModel, progressEvent.getCallbackContext());
+        }
+
+        logger.log(String.format("Going to remove tags for MSK ServerlessCluster resource: " +
+            "%s with AccountId: %s", resourceModel.getClusterName(), handlerRequest.getAwsAccountId()));
+
+        return proxy.initiate("AWS-MSK-ServerlessCluster::UntagResource", serviceClient, resourceModel, callbackContext)
+            .translateToServiceRequest(model ->
+                Translator.translateToUntagResourceRequest(model, removedTags))
+            .makeServiceCall((untagResourceRequest, _proxyClient) -> _proxyClient.injectCredentialsAndInvokeV2(
+                untagResourceRequest, _proxyClient.client()::untagResource))
+            .handleError((untagResourceRequest, exception, _proxyClient, _resourceModel, _callbackContext) ->
+                handleError(exception, resourceModel,  callbackContext, logger, clientRequestToken))
+            .progress();
+    }
+}

--- a/aws-msk-serverlesscluster/src/test/java/software/amazon/msk/serverlesscluster/AbstractTestBase.java
+++ b/aws-msk-serverlesscluster/src/test/java/software/amazon/msk/serverlesscluster/AbstractTestBase.java
@@ -29,9 +29,7 @@ public class AbstractTestBase {
 
     protected static final String CLIENT_REQUEST_TOKEN = "ClientToken";
     protected static final String CLUSTER_NAME = "ClusterName";
-    protected static final String CLUSTER_NAME_2 = "ClusterName2";
     protected static final String CLUSTER_ARN = "arn:aws:kafka:us-west-2:083674906042:cluster/ClusterName";
-    protected static final String CLUSTER_ARN_2 = "arn:aws:kafka:us-west-2:083674906042:cluster/ClusterName2";
     protected static final Set<String> SECURITY_GROUP_IDS = Sets.newHashSet("SecurityGroup");
     protected static final Set<String> SUBNET_IDS =  Sets.newHashSet("Subnets");
     protected static final ClientAuthentication CLIENT_AUTHENTICATION =
@@ -43,6 +41,24 @@ public class AbstractTestBase {
         {
             put("TEST_TAG1", "TEST_TAG_VALUE1");
             put("TEST_TAG2", "TEST_TAG_VALUE2");
+        }
+    };
+    protected static final Map<String, String> TAGS_ADDED = new HashMap<String, String>() {
+        {
+            put("TEST_TAG1", "TEST_TAG_VALUE1");
+            put("TEST_TAG2", "TEST_TAG_VALUE2");
+            put("TEST_TAG3", "TEST_TAG_VALUE3");
+        }
+    };
+    protected static final Map<String, String> TAGS_REMOVED = new HashMap<String, String>() {
+        {
+            put("TEST_TAG1", "TEST_TAG_VALUE1");
+        }
+    };
+    protected static final Map<String, String> TAGS_ALTERED = new HashMap<String, String>() {
+        {
+            put("TEST_TAG1", "TEST_TAG_VALUE1");
+            put("TEST_TAG3", "TEST_TAG_VALUE3");
         }
     };
 
@@ -103,6 +119,16 @@ public class AbstractTestBase {
             .clientAuthentication(CLIENT_AUTHENTICATION)
             .vpcConfigs(Sets.newHashSet(VPC_CONFIG_LIST))
             .tags(TAGS)
+            .build();
+    }
+
+    protected static ResourceModel buildResourceModelWithTags(Map<String, String> tags) {
+        return ResourceModel.builder()
+            .clusterName(CLUSTER_NAME)
+            .arn(CLUSTER_ARN)
+            .clientAuthentication(CLIENT_AUTHENTICATION)
+            .vpcConfigs(Sets.newHashSet(VPC_CONFIG_LIST))
+            .tags(tags)
             .build();
     }
 

--- a/aws-msk-serverlesscluster/src/test/java/software/amazon/msk/serverlesscluster/ClientBuilderTest.java
+++ b/aws-msk-serverlesscluster/src/test/java/software/amazon/msk/serverlesscluster/ClientBuilderTest.java
@@ -1,0 +1,18 @@
+package software.amazon.msk.serverlesscluster;
+
+import org.junit.jupiter.api.Test;
+
+import software.amazon.awssdk.services.kafka.KafkaClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ClientBuilderTest extends AbstractTestBase {
+
+    @Test
+    public void test_getKafkaClient() {
+        // When
+        KafkaClient kafkaClient = ClientBuilder.getClient();
+        // Then
+        assertThat(kafkaClient).isNotNull();
+    }
+}

--- a/aws-msk-serverlesscluster/src/test/java/software/amazon/msk/serverlesscluster/UpdateHandlerTest.java
+++ b/aws-msk-serverlesscluster/src/test/java/software/amazon/msk/serverlesscluster/UpdateHandlerTest.java
@@ -1,0 +1,215 @@
+package software.amazon.msk.serverlesscluster;
+
+import java.time.Duration;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.services.kafka.KafkaClient;
+import software.amazon.awssdk.services.kafka.model.BadRequestException;
+import software.amazon.awssdk.services.kafka.model.Cluster;
+import software.amazon.awssdk.services.kafka.model.ClusterState;
+import software.amazon.awssdk.services.kafka.model.DescribeClusterV2Request;
+import software.amazon.awssdk.services.kafka.model.DescribeClusterV2Response;
+import software.amazon.awssdk.services.kafka.model.ForbiddenException;
+import software.amazon.awssdk.services.kafka.model.InternalServerErrorException;
+import software.amazon.awssdk.services.kafka.model.KafkaException;
+import software.amazon.awssdk.services.kafka.model.ServiceUnavailableException;
+import software.amazon.awssdk.services.kafka.model.TagResourceRequest;
+import software.amazon.awssdk.services.kafka.model.TagResourceResponse;
+import software.amazon.awssdk.services.kafka.model.UnauthorizedException;
+import software.amazon.awssdk.services.kafka.model.UntagResourceRequest;
+import software.amazon.awssdk.services.kafka.model.UntagResourceResponse;
+import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class UpdateHandlerTest extends AbstractTestBase {
+
+    @Mock
+    private AmazonWebServicesClientProxy proxy;
+
+    @Mock
+    private ProxyClient<KafkaClient> proxyClient;
+
+    @Mock
+    KafkaClient kafkaClient;
+
+    private UpdateHandler updateHandler;
+
+    private static Stream<Arguments> requestKafkaErrorToCfnError() {
+        return Stream.of(
+            arguments(InternalServerErrorException.class, HandlerErrorCode.InternalFailure),
+            arguments(ForbiddenException.class, HandlerErrorCode.InvalidRequest),
+            arguments(ServiceUnavailableException.class, HandlerErrorCode.ServiceInternalError),
+            arguments(UnauthorizedException.class, HandlerErrorCode.InvalidRequest),
+            arguments(BadRequestException.class, HandlerErrorCode.InvalidRequest),
+            arguments(IllegalArgumentException.class, HandlerErrorCode.InvalidRequest),
+            arguments(AwsServiceException.class, HandlerErrorCode.GeneralServiceException));
+    }
+
+    @BeforeEach
+    public void setup() {
+        proxy = new AmazonWebServicesClientProxy(logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
+        kafkaClient = mock(KafkaClient.class);
+        proxyClient = MOCK_PROXY(proxy, kafkaClient);
+        updateHandler = new UpdateHandler();
+    }
+
+    @AfterEach
+    public void tear_down() {
+        verifyNoMoreInteractions(kafkaClient);
+    }
+
+    @Test
+    public void handleRequest_SimpleSuccess() {
+        // Given
+        final TagResourceResponse tagResourceResponse = TagResourceResponse.builder().build();
+        final UntagResourceResponse untagResourceResponse = UntagResourceResponse.builder().build();
+        when(proxyClient.client().tagResource(any(TagResourceRequest.class))).thenReturn(tagResourceResponse);
+        when(proxyClient.client().untagResource(any(UntagResourceRequest.class))).thenReturn(untagResourceResponse);
+
+        Cluster desiredCluster = getServerlessCluster(ClusterState.ACTIVE);
+        final DescribeClusterV2Response describeClusterResponse =
+            DescribeClusterV2Response.builder().clusterInfo(desiredCluster).build();
+        when(proxyClient.client().describeClusterV2(any(DescribeClusterV2Request.class)))
+            .thenReturn(describeClusterResponse);
+
+        // When
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .previousResourceState(buildResourceModelWithTags(TAGS_ALTERED))
+            .desiredResourceState(buildResourceModel())
+            .clientRequestToken(CLIENT_REQUEST_TOKEN)
+            .build();
+        final ProgressEvent<ResourceModel, CallbackContext> response = updateHandler.handleRequest(proxy, request,
+            new CallbackContext(), proxyClient, logger);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+
+        assertThat(response.getResourceModel().getClusterName())
+            .isEqualTo(request.getDesiredResourceState().getClusterName());
+        assertThat(response.getResourceModel().getClientAuthentication())
+            .isEqualTo(request.getDesiredResourceState().getClientAuthentication());
+        assertThat(response.getResourceModel().getVpcConfigs())
+            .isEqualTo(request.getDesiredResourceState().getVpcConfigs());
+        assertThat(response.getResourceModel().getTags())
+            .isEqualTo(request.getDesiredResourceState().getTags());
+        assertThat(response.getResourceModel().getArn())
+            .isEqualTo(request.getDesiredResourceState().getArn());
+
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+
+        verify(proxyClient.client()).untagResource(any(UntagResourceRequest.class));
+        verify(proxyClient.client()).tagResource(any(TagResourceRequest.class));
+        verify(proxyClient.client(), times(1)).describeClusterV2(any(DescribeClusterV2Request.class));
+        verify(kafkaClient, atLeastOnce()).serviceName();
+    }
+
+    @Test
+    public void handleRequest_withoutPreviousResourceState_throwsCfnInvalidRequestException() {
+        // Given
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(buildResourceModel())
+            .clientRequestToken(CLIENT_REQUEST_TOKEN)
+            .build();
+
+        // When & Then
+        assertThatThrownBy(
+            () -> updateHandler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger))
+            .isInstanceOf(CfnInvalidRequestException.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("requestKafkaErrorToCfnError")
+    public void handleRequest_untagRequestThrowsException(Class<KafkaException> kafkaException,
+                                                          HandlerErrorCode cfnError) {
+        // Given
+        when(proxyClient.client().untagResource(any(UntagResourceRequest.class)))
+            .thenThrow(kafkaException);
+
+        // When
+        final ResourceHandlerRequest<ResourceModel> request =
+            ResourceHandlerRequest.<ResourceModel>builder()
+                .previousResourceState(buildResourceModel())
+                .desiredResourceState(buildResourceModelWithTags(TAGS_REMOVED))
+                .clientRequestToken(CLIENT_REQUEST_TOKEN)
+                .previousResourceTags(TAGS)
+                .desiredResourceTags(TAGS_REMOVED)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response =
+            updateHandler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getErrorCode()).isEqualTo(cfnError);
+
+        verify(proxyClient.client()).untagResource(any(UntagResourceRequest.class));
+        verify(kafkaClient, atLeastOnce()).serviceName();
+    }
+
+    @ParameterizedTest
+    @MethodSource("requestKafkaErrorToCfnError")
+    public void handleRequest_tagRequestThrowsException(Class<KafkaException> kafkaException,
+                                                        HandlerErrorCode cfnError) {
+        // Given
+        when(proxyClient.client().tagResource(any(TagResourceRequest.class)))
+            .thenThrow(kafkaException);
+
+        // When
+        final ResourceHandlerRequest<ResourceModel> request =
+            ResourceHandlerRequest.<ResourceModel>builder()
+                .previousResourceState(buildResourceModel())
+                .desiredResourceState(buildResourceModelWithTags(TAGS_ADDED))
+                .clientRequestToken(CLIENT_REQUEST_TOKEN)
+                .previousResourceTags(TAGS)
+                .desiredResourceTags(TAGS_ADDED)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response =
+            updateHandler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getErrorCode()).isEqualTo(cfnError);
+
+        verify(proxyClient.client()).tagResource(any(TagResourceRequest.class));
+        verify(proxyClient.client(), times(0)).untagResource(any(UntagResourceRequest.class));
+        verify(kafkaClient, atLeastOnce()).serviceName();
+    }
+}


### PR DESCRIPTION
*Issue*
- https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/1432

*Description of changes:*
- Add support for updatable tagging
- Add UpdateHandler to handle tag update
- Add unit tests for UpdateHandler

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
